### PR TITLE
Revert "Previous splits and merge uid and iuid"

### DIFF
--- a/pyfortracc/cluster_linking/cluster_linking.py
+++ b/pyfortracc/cluster_linking/cluster_linking.py
@@ -157,26 +157,6 @@ def linking(args):
     previous_iuids = prv_frame.loc[prv_idx]['iuid'].values
     cur_frame.loc[cur_idx, 'uid'] = previous_uids
     cur_frame.loc[cur_idx, 'iuid'] = previous_iuids
-    # merge uids and iuids
-    mrg_frame = cur_frame.loc[(~cur_frame['merge_idx'].isnull())]
-    if not mrg_frame.empty:
-        mrg_frame[['prv_mrg_uids', 'prv_mrg_iuids']] = mrg_frame.apply(
-            lambda x: pd.Series({
-                'prv_mrg_uids': prv_frame.loc[x['merge_idx'], 'uid'].to_list(),
-                'prv_mrg_iuids': prv_frame.loc[x['merge_idx'], 'iuid'].to_list()
-            }),
-            axis=1)
-        cur_frame.loc[mrg_frame.index,['prv_mrg_uids', 'prv_mrg_iuids']] = mrg_frame[['prv_mrg_uids', 'prv_mrg_iuids']]
-    # split uid and iuid
-    spl_frame = cur_frame.loc[(~cur_frame['split_pr_idx'].isnull())]
-    if not spl_frame.empty:
-        spl_frame[['prv_spl_uid', 'prv_spl_iuid']] = spl_frame.apply(
-            lambda x: pd.Series({
-                'prv_spl_uid': prv_frame.loc[x['split_pr_idx'], 'uid'],
-                'prv_spl_iuid': prv_frame.loc[x['split_pr_idx'], 'iuid']
-            }),
-            axis=1)
-        cur_frame.loc[spl_frame.index,['prv_spl_uid', 'prv_spl_iuid']] = spl_frame[['prv_spl_uid', 'prv_spl_iuid']]
     # Merge trajectories
     cur_frame = merge_trajectory(cur_frame, cur_idx, prv_frame, prv_idx)
     # New frames for base threshold

--- a/pyfortracc/concat.py
+++ b/pyfortracc/concat.py
@@ -220,11 +220,7 @@ def default_columns(name_list=None):
                 'array_x',
                 'vector_field',
                 'trajectory',
-                'geometry',
-                'prv_mrg_uids', 
-               'prv_mrg_iuids',
-               'prv_spl_uid,
-               'prv_spl_iuid]
+                'geometry']
     if len(name_list['thresholds']) > 1:
         # columns = columns + ['iuid']
         # Get position of uid column and add iuid after it

--- a/pyfortracc/utilities/utils.py
+++ b/pyfortracc/utilities/utils.py
@@ -448,10 +448,6 @@ def set_schema(module,name_list):
                 'threshold_level': int,
                 'lifetime': int,
                 'trajectory': str,
-                'prv_mrg_uids': list,
-                'prv_mrg_iuids': list,
-                'prv_spl_uid': float,
-                'prv_spl_iuid': float,
             }
         }
     # Add the methods field to spatial schema


### PR DESCRIPTION
Reverts fortracc/pyfortracc#13

Traceback (most recent call last):

  File "/usr/local/lib/python3.10/dist-packages/IPython/core/interactiveshell.py", line 3553, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  File ["<ipython-input-7-79f71be5aae4>"](https://localhost:8080/#), line 2, in <cell line: 2>
    from pyfortracc import track

  File "/usr/local/lib/python3.10/dist-packages/pyfortracc/__init__.py", line 63, in <module>
    from pyfortracc.track import track

  File "/usr/local/lib/python3.10/dist-packages/pyfortracc/track.py", line 5, in <module>
    from .concat import concat

  File "/usr/local/lib/python3.10/dist-packages/pyfortracc/concat.py", line 226
    'prv_spl_uid,
    ^
SyntaxError: unterminated string literal (detected at line 226)